### PR TITLE
Use existing `QApplication`

### DIFF
--- a/blacs/__main__.py
+++ b/blacs/__main__.py
@@ -821,7 +821,9 @@ if __name__ == '__main__':
     logger.info('connection table loaded')
 
     splash.update_text('initialising Qt application')
-    qapplication = QApplication(sys.argv)
+    qapplication = QApplication.instance()
+    if qapplication is None:
+        qapplication = QApplication(sys.argv)
     qapplication.setAttribute(Qt.AA_DontShowIconsInMenus, False)
     logger.info('QApplication instantiated')
     app = BLACS(qapplication)


### PR DESCRIPTION
Instead of creating a new one unconditionally. The splash screen already
creates a `QApplication`, so we had two existing in the interpreter.
Having multiple `QApplication`s in the same thread (possibly in the same
process?) is not allowed and leads to segfaults on `PyQt5` and Python
exceptions on `PySide2`.

Initially reported in labscript-suite/runmanager#74