### PR TITLE
Obtain own version without external functions

### DIFF
--- a/blacs/__init__.py
+++ b/blacs/__init__.py
@@ -13,10 +13,6 @@
 from __future__ import division, unicode_literals, print_function, absolute_import
 import os
 
-from labscript_utils.versions import get_version, NoVersionInfo
-from pathlib import Path
-__version__ = get_version(__name__, import_path=Path(__file__).parent.parent)
-if __version__ is NoVersionInfo:
-    __version__ = None
+from .__version__ import __version__
 
 BLACS_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/blacs/__version__.py
+++ b/blacs/__version__.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
+
+root = Path(__file__).parent.parent
+if (root / '.git').is_dir():
+    from setuptools_scm import get_version
+    __version__ = get_version(root, **VERSION_SCHEME)
+else:
+    try:
+        __version__ = importlib_metadata.version(__package__)
+    except importlib_metadata.PackageNotFoundError:
+        __version__ = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.6
 install_requires =
-  importlib_metadata ; python_version<'3.8'
+  importlib_metadata
   labscript_devices>=2.0
   labscript_utils>=2.15.0
   qtutils>=2.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.6
 install_requires =
+  importlib_metadata ; python_version<'3.8'
   labscript_devices>=2.0
   labscript_utils>=2.15.0
   qtutils>=2.3.2


### PR DESCRIPTION
Per labscript-suite/runmanager#81, with the addition of making the importlib_metadata requirement python<'3.8'.