### PR TITLE
Move config path to same location as other apps

### DIFF
--- a/blacs/__main__.py
+++ b/blacs/__main__.py
@@ -146,6 +146,7 @@ from labscript_utils.connections import ConnectionTable
 from labscript_utils.qtwidgets.dragdroptab import DragDropTabWidget
 # Lab config code
 from labscript_utils.labconfig import LabConfig
+from labscript_profile import hostname
 # Qt utils for running functions in the main thread
 from qtutils import *
 # And for icons:
@@ -786,7 +787,7 @@ if __name__ == '__main__':
     settings_dir = Path(exp_config.get('DEFAULT', 'app_saved_configs'), 'blacs')
     if not settings_dir.exists():
         os.makedirs(settings_dir, exist_ok=True)
-    settings_path = str(settings_dir / 'BLACS.h5')
+    settings_path = str(settings_dir / f'{hostname()}_BLACS.h5')
 
     port = int(exp_config.get('ports','BLACS'))
 

--- a/blacs/__main__.py
+++ b/blacs/__main__.py
@@ -44,6 +44,7 @@ import socket
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 import signal
 # Quit on ctrl-c
@@ -144,7 +145,7 @@ from labscript_utils.connections import ConnectionTable
 #Draggable Tab Widget Code
 from labscript_utils.qtwidgets.dragdroptab import DragDropTabWidget
 # Lab config code
-from labscript_utils.labconfig import LabConfig, config_prefix, hostname
+from labscript_utils.labconfig import LabConfig
 # Qt utils for running functions in the main thread
 from qtutils import *
 # And for icons:
@@ -773,21 +774,19 @@ if __name__ == '__main__':
                                       'labscript_utils.labconfig',
                                       'zprocess',
                                      ], sub=True)
-        ##########
 
     splash.update_text('loading labconfig')
-    settings_path = os.path.join(config_prefix,'%s_BLACS.h5'%hostname)
-    required_config_params = {"DEFAULT":["experiment_name"],
-                              "programs":["text_editor",
-                                          "text_editor_arguments",
-                                         ],
-                              "paths":["shared_drive",
-                                       "connection_table_h5",
-                                       "connection_table_py",
-                                      ],
-                              "ports":["BLACS", "lyse"],
-                             }
-    exp_config = LabConfig(required_params = required_config_params)
+    required_config_params = {
+        "DEFAULT": ["experiment_name", "app_saved_configs"],
+        "programs": ["text_editor", "text_editor_arguments",],
+        "paths": ["shared_drive", "connection_table_h5", "connection_table_py",],
+        "ports": ["BLACS", "lyse"],
+    }
+    exp_config = LabConfig(required_params=required_config_params)
+    settings_dir = Path(exp_config.get('DEFAULT', 'app_saved_configs'), 'blacs')
+    if not settings_dir.exists():
+        os.makedirs(settings_dir, exist_ok=True)
+    settings_path = str(settings_dir / 'BLACS.h5')
 
     port = int(exp_config.get('ports','BLACS'))
 


### PR DESCRIPTION
And have it named BLACS.h5 instead of containing the hostname.

This ensures we don't use variables no longer defined in
`labscript_utils.labconfig` as of labscript-suite/labscript-utils#45,
whilst also conforming to a more standard layout of where the config
file is stored.

A nice side effect of storing the BLACS config in the app_saved_configs
dir is that if the user changes the experiment name in their labconfig
file, they can switch between BLACS configs from different experiments
without having to recompile the connection table, change globals files
in BLACS, etc. So different experiments on the same machine can have a
more self-contained config.

I don't see much upside to keeping the hostname in the config filename,
so now it's just BLACS.h5. With labconfig there is at least the idea
that you might version control the labconfig directory to share changes
between computers, but that is not as useful for BLACS' config.