### PR TITLE
Fix Bug in AO.__init__() When Unit Conversion Import Fails

### DIFF
--- a/blacs/output_classes.py
+++ b/blacs/output_classes.py
@@ -62,8 +62,8 @@ class AO(object):
             if cls is None or not isinstance(calib_params, dict) or cls.base_unit != default_units:
                 # log an error:  
                 reason = ''
-                if calib_class is None:
-                    reason = f'The unit conversion class {calib_class} could not be imported. Ensure it is available on the computer running BLACS.'
+                if cls is None:
+                    reason = f'The unit conversion class {cls} could not be imported. Ensure it is available on the computer running BLACS.'
                 elif not isinstance(calib_params, dict):
                     reason = 'The parameters for the unit conversion class are not a dictionary. Check your connection table code for errors and recompile it'
                 elif cls.base_unit != default_units:

--- a/blacs/output_classes.py
+++ b/blacs/output_classes.py
@@ -63,7 +63,7 @@ class AO(object):
                 # log an error:  
                 reason = ''
                 if cls is None:
-                    reason = f'The unit conversion class {cls} could not be imported. Ensure it is available on the computer running BLACS.'
+                    reason = f'The unit conversion class {calib_class} could not be imported. Ensure it is available on the computer running BLACS.'
                 elif not isinstance(calib_params, dict):
                     reason = 'The parameters for the unit conversion class are not a dictionary. Check your connection table code for errors and recompile it'
                 elif cls.base_unit != default_units:


### PR DESCRIPTION
`AO.__init__()` is supposed to log an error if it can't import the specified unit conversion class. This is designed to work by setting `cls = None` if the class can't be imported, which should then trigger the `'The unit conversion class {cls} could not be imported...'` error message to be logged.

Previously this failed due to `cls` mistakenly being replaced with `calib_class`, so the `if` statement to generate that error message didn't get triggered. That would cause the `cls.base_unit != default_units` statement in the later `elif` clause to raise `AttributeError: 'NoneType' object has no attribute 'base_unit'`.

It's clear that this is a simple mixup since the `if calib_class is None:` statement occurs inside a `if calib_class is not None:` block so it could never get triggered. This PR corrects this little mixup.