### PR TITLE
Update default setuptools_scm version scheme to release-branch-semver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ defaults:
 
 env:
   PACKAGE_NAME: blacs
-  SCM_VERSION_SCHEME: release-branch-semver
   SCM_LOCAL_SCHEME: no-local-version
   ANACONDA_USER: labscript-suite
 

--- a/blacs/__version__.py
+++ b/blacs/__version__.py
@@ -5,15 +5,10 @@ try:
 except ImportError:
     import importlib_metadata
 
-VERSION_SCHEME = {
-    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
-    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
-}
-
 root = Path(__file__).parent.parent
 if (root / '.git').is_dir():
     from setuptools_scm import get_version
-    __version__ = get_version(root, **VERSION_SCHEME)
+    __version__ = get_version(root, version_scheme="release-branch-semver")
 else:
     try:
         __version__ = importlib_metadata.version(__package__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=4.1.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
   labscript_devices>=3.0.0
   labscript_utils>=3.0.0
   qtutils>=2.3.2
+  setuptools_scm>=4.1.0
   zprocess>=2.14.1
 
 [options.entry_points]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup
 
 VERSION_SCHEME = {
-    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "release-branch-semver"),
     "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
 }
 


### PR DESCRIPTION
This fixes the circular dependency issue between blacs and labscript-devices that is preventing #80 from building. By extension, allows for proper pip develop installs locally, where this circular dependency issue is manifesting.

Pretty sure I got all the tweaks from labscript-utils, but best to make sure I didn't miss anything, especially where the workflows/RTD stuff is concerned since that is harder to test locally.

This should be merged at same time as labscript-suite/labscript-devices#73