### PR TITLE
Upgrade 'run time' to datetime timestamp.

### DIFF
--- a/blacs/experiment_queue.py
+++ b/blacs/experiment_queue.py
@@ -15,6 +15,7 @@ import logging
 import os
 import threading
 import time
+import datetime
 import sys
 import shutil
 from collections import defaultdict
@@ -722,7 +723,7 @@ class QueueManager(object):
                 # A Queue for event-based notification of when the experiment has finished.
                 experiment_finished_queue = queue.Queue()
                 logger.debug('About to start the master pseudoclock')
-                run_time = time.localtime()
+                run_time = datetime.datetime.now()
 
                 ##########################################################################################################################################
                 #                                                        Plugin callbacks                                                                #
@@ -850,7 +851,7 @@ class QueueManager(object):
 
                     data_group = hdf5_file['/'].create_group('data')
                     # stamp with the run time of the experiment
-                    hdf5_file.attrs['run time'] = time.strftime('%Y%m%dT%H%M%S',run_time)
+                    hdf5_file.attrs['run time'] = run_time.strftime('%Y%m%dT%H%M%S.%f')
         
                 error_condition = False
                 response_list = {}


### PR DESCRIPTION
This gives the saved 'run time' resolution better than 1 second.

Note that while datetime gives a number with resolution down to the microsecond, actual accuracy/resolution will be what the host system can provide (which can be as poor as 1 second). However, on most systems the timing accuracy is better than 1 second. So in the worst case, this just adds extra numbers users will need to ignore. In general, it should provide somewhat better timing resolution for the run start.