### PR TITLE
Only pass ints to self.ui.move

### DIFF
--- a/blacs/__main__.py
+++ b/blacs/__main__.py
@@ -464,8 +464,17 @@ class BLACS(object):
             # Actually this is a waste of time because if you close when maximized, reoopen and then
             # de-maximize, the window moves to a random position (not the position it was at before maximizing)
             # so bleh!
-            self.ui.move(tab_data['BLACS settings']["window_xpos"]-tab_data['BLACS settings']['window_frame_width']/2,tab_data['BLACS settings']["window_ypos"]-tab_data['BLACS settings']['window_frame_height']+tab_data['BLACS settings']['window_frame_width']/2)
-            self.ui.resize(tab_data['BLACS settings']["window_width"],tab_data['BLACS settings']["window_height"])
+            self.ui.move(
+                tab_data['BLACS settings']["window_xpos"]
+                - tab_data['BLACS settings']['window_frame_width'] // 2,
+                tab_data['BLACS settings']["window_ypos"]
+                - tab_data['BLACS settings']['window_frame_height']
+                + tab_data['BLACS settings']['window_frame_width'] // 2,
+            )
+            self.ui.resize(
+                tab_data['BLACS settings']["window_width"],
+                tab_data['BLACS settings']["window_height"],
+            )
 
             if 'window_maximized' in tab_data['BLACS settings'] and tab_data['BLACS settings']['window_maximized']:
                 self.ui.showMaximized()
@@ -474,7 +483,7 @@ class BLACS(object):
                 pane.setSizes(tab_data['BLACS settings'][pane_name])
 
         except Exception as e:
-            logger.warning("Unable to load window and notebook defaults. Exception:"+str(e))
+            logger.exception("Unable to load window and notebook defaults. Exception:"+str(e))
 
     def order_tabs(self,tab_data):
         # Move the tabs to the correct notebook


### PR DESCRIPTION
as floats to QWidget.move are depreceated and raise an exception.

Also update the log line to print the full exception for easier detection of issues in the future.