### PR TITLE
adding logic to handle KeyError: "Unable to open object (object 'connection table' doesn't exist)" on initial run

### DIFF
--- a/blacs/front_panel_settings.py
+++ b/blacs/front_panel_settings.py
@@ -24,7 +24,7 @@ from qtutils import *
 
 from labscript_utils.connections import ConnectionTable
 
-logger = logging.getLogger('BLACS.FrontPanelSettings')  
+logger = logging.getLogger('BLACS.FrontPanelSettings')
 
 def _ensure_str(s):
     """convert bytestrings and numpy strings to python strings"""
@@ -36,7 +36,7 @@ class FrontPanelSettings(object):
         self.connection_table = connection_table
         with h5py.File(settings_path,'a') as h5file:
             pass
-        
+
     def setup(self,blacs):
         self.tablist = blacs.tablist
         self.attached_devices = blacs.attached_devices
@@ -46,7 +46,10 @@ class FrontPanelSettings(object):
         self.blacs = blacs
 
     def restore(self):
-        
+
+        # See if connection table exists in apparatus h5 file
+        # Return if not
+        #
         # Get list of DO/AO
         # Does the object have a name?
         #    yes: Then, find the device in the BLACS connection table that matches that name
@@ -63,20 +66,29 @@ class FrontPanelSettings(object):
         #            no: Restore as is
         #
         # Display errors, give option to cancel starting of BLACS so that the connection table can be edited
-        
+
         # Create saved connection table
         settings = {}
         question = {}
         error = {}
         tab_data = {'BLACS settings':{}}
         try:
+            with h5py.File(settings_path,'r') as h5file:
+                if 'connection table' in h5file:
+                    logger.info('Settings connection table found in file')
+        except:
+            logger.info('connection table not in file yet')
+            return settings,question,error,tab_data
+
+        try:
+
             saved_ct = ConnectionTable(self.settings_path, logging_prefix='BLACS', exceptions_in_thread=True)
             ct_match,error = self.connection_table.compare_to(saved_ct)
-            
+
             with h5py.File(self.settings_path,'r') as hdf5_file:
                 # Get Tab Data
                 dataset = hdf5_file['/front_panel'].get('_notebook_data',[])
-                
+
                 for row in dataset:
                     tab_name = _ensure_str(row['tab_name'])
                     tab_data.setdefault(tab_name,{})
@@ -84,10 +96,10 @@ class FrontPanelSettings(object):
                         tab_data[tab_name] = {'notebook':row['notebook'], 'page':row['page'], 'visible':row['visible'], 'data':eval(_ensure_str(row['data']))}
                     except Exception:
                         logger.info("Could not load tab data for %s"%tab_name)
-                
+
                 #now get dataset attributes
                 tab_data['BLACS settings'] = dict(dataset.attrs)
-                
+
                 # Get the front panel values
                 if 'front_panel' in hdf5_file["/front_panel"]:
                     dataset = hdf5_file["/front_panel"].get('front_panel', [])
@@ -101,7 +113,7 @@ class FrontPanelSettings(object):
                             else:
                                 data_dict[columns[i]] = row[i]
                         settings,question,error = self.handle_return_code(data_dict,result,settings,question,error)
-      
+
                 # Else Legacy restore from GTK save data!
                 else:
                     # open Datasets
@@ -119,7 +131,7 @@ class FrontPanelSettings(object):
             logger.info("Could not load saved settings")
             logger.info(str(e))
         return settings,question,error,tab_data
-    
+
     def handle_return_code(self,row,result,settings,question,error):
         # 1: Restore to existing device
         # 2: Send to new device
@@ -131,7 +143,7 @@ class FrontPanelSettings(object):
         if type(result) == tuple:
             connection = result[1]
             result = result[0]
-        
+
         if result == 1:
             settings.setdefault(row['device_name'],{})
             settings[row['device_name']][row['channel']] = row
@@ -145,10 +157,10 @@ class FrontPanelSettings(object):
             error[row['device_name']+'_'+row['channel']] = row,"missing"
         elif result == -2:
             error[row['device_name']+'_'+row['channel']] = row,"changed"
-            
+
         return settings,question,error
-    
-    def check_row(self,row,ct_match,blacs_ct,saved_ct):            
+
+    def check_row(self,row,ct_match,blacs_ct,saved_ct):
         # If it has a name
         if row[0] != "-":
             if ct_match:
@@ -158,7 +170,7 @@ class FrontPanelSettings(object):
                 # Find if this device is in the connection table
                 connection = blacs_ct.find_by_name(row[0])
                 connection2 = saved_ct.find_by_name(row[0])
-                
+
                 if connection:
                     # compare the two connections, see what differs
                     # if compare fails only on parent, connected to:
@@ -166,13 +178,13 @@ class FrontPanelSettings(object):
                     # else:
                     #     show error, device parameters not compatible with saved data
                     result,error = connection.compare_to(connection2)
-                    
+
                     allowed_length = 0
                     if "parent_port" in error:
                         allowed_length += 1
-                        
+
                     if len(error) > allowed_length:
-                        return -2 # failure, device parameters not compatible                        
+                        return -2 # failure, device parameters not compatible
                     elif error == {} and connection.parent.name == connection2.parent.name:
                         return 1 # All details about this device match
                     else:
@@ -190,46 +202,46 @@ class FrontPanelSettings(object):
             else:
                 # restore to device
                 return 1
-    
-    @inmain_decorator(wait_for_return=True)    
+
+    @inmain_decorator(wait_for_return=True)
     def get_save_data(self):
         tab_data = {}
         notebook_data = {}
         window_data = {}
         plugin_data = {}
-        
+
         # iterate over all tabs
         for device_name,tab in self.tablist.items():
             tab_data[device_name] = {'front_panel':tab.settings['front_panel_settings'], 'save_data': tab.get_all_save_data()}
-            
+
             # Find the notebook the tab is in
-            #            
-            # By default we assume it is in notebook0, on page 0. This way, if a tab gets lost somewhere, 
-            # and isn't found to be a child of any notebook we know about, 
+            #
+            # By default we assume it is in notebook0, on page 0. This way, if a tab gets lost somewhere,
+            # and isn't found to be a child of any notebook we know about,
             # it will revert back to notebook 1 when the file is loaded upon program restart!
-            current_notebook_name = 0 
+            current_notebook_name = 0
             page = 0
             visible = False
-            
+
             for notebook_name,notebook in self.notebook.items():
-                if notebook.indexOf(tab._ui) != -1:                
-                    current_notebook_name = notebook_name 
-                    page = notebook.indexOf(tab._ui) 
-                    visible = True if notebook.currentIndex() == page else False   
+                if notebook.indexOf(tab._ui) != -1:
+                    current_notebook_name = notebook_name
+                    page = notebook.indexOf(tab._ui)
+                    visible = True if notebook.currentIndex() == page else False
                     break
-                                
+
             notebook_data[device_name] = {"notebook":current_notebook_name,"page":page, "visible":visible}
-        
+
         # iterate over all plugins
         for module_name, plugin in self.blacs.plugins.items():
             try:
                 plugin_data[module_name] = plugin.get_save_data()
             except Exception as e:
                 logger.error('Could not save data for plugin %s. Error was: %s'%(module_name,str(e)))
-        
+
         # save window data
-        # Size of window       
-        window_data["_main_window"] = {"width":self.window.normalGeometry().width(), 
+        # Size of window
+        window_data["_main_window"] = {"width":self.window.normalGeometry().width(),
                                        "height":self.window.normalGeometry().height(),
                                        "xpos":self.window.normalGeometry().x(),
                                        "ypos":self.window.normalGeometry().y(),
@@ -242,24 +254,24 @@ class FrontPanelSettings(object):
         # Pane positions
         for name,pane in self.panes.items():
             window_data[name] = pane.sizes()
-        
+
         return tab_data,notebook_data,window_data,plugin_data
-    
+
     @inmain_decorator(wait_for_return=True)
-    def save_front_panel_to_h5(self,current_file,states,tab_positions,window_data,plugin_data,silent = {}, force_new_conn_table = False):        
+    def save_front_panel_to_h5(self,current_file,states,tab_positions,window_data,plugin_data,silent = {}, force_new_conn_table = False):
         # Save the front panel!
 
-        # Does the file exist?            
+        # Does the file exist?
         #   Yes: Check connection table inside matches current connection table. Does it match?
         #        Yes: Does the file have a front panel already saved in it?
         #               Yes: Can we overwrite?
         #                  Yes: Delete front_panel group, save new front panel
         #                  No:  Create error dialog!
         #               No: Save front panel in here
-        #   
+        #
         #        No: Return
         #   No: Create new file, place inside the connection table and front panel
-            
+
         if os.path.isfile(current_file):
             save_conn_table = True if force_new_conn_table else False
             result = False
@@ -270,10 +282,10 @@ class FrontPanelSettings(object):
                 except Exception:
                     # no connection table is present, so also save the connection table!
                     save_conn_table = True
-            
+
             # if save_conn_table is True, we don't bother checking to see if the connection tables match, because save_conn_table is only true when the connection table doesn't exist in the current file
             # As a result, if save_conn_table is True, we ignore connection table checking, and save the connection table in the h5file.
-            
+
             if save_conn_table or result:
                 with h5py.File(current_file,'r+') as hdf5_file:
                     if hdf5_file['/'].get('front_panel') != None:
@@ -288,18 +300,18 @@ class FrontPanelSettings(object):
                             message.setIcon(QMessageBox.Question)
                             message.setWindowTitle("BLACS")
                             resp = message.exec_()
-                                                
+
                             if resp == QMessageBox.Yes :
-                                overwrite = True   
+                                overwrite = True
                         else:
                             overwrite = silent["overwrite"]
-                        
+
                         if overwrite:
                             # Delete Front panel group, save new front panel
                             del hdf5_file['/front_panel']
                             self.store_front_panel_in_h5(hdf5_file,states,tab_positions,window_data,plugin_data,save_conn_table)
                         else:
-                            if not silent:                               
+                            if not silent:
                                 message = QMessageBox()
                                 message.setText("Front Panel not saved.")
                                 message.setIcon(QMessageBox.Information)
@@ -308,7 +320,7 @@ class FrontPanelSettings(object):
                             else:
                                 logger.info("Front Panel not saved as it already existed in the h5 file '"+current_file+"'")
                             return
-                    else: 
+                    else:
                         # Save Front Panel in here
                         self.store_front_panel_in_h5(hdf5_file,states,tab_positions,window_data,plugin_data,save_conn_table)
             else:
@@ -318,32 +330,32 @@ class FrontPanelSettings(object):
                     message.setText("The Front Panel was not saved as the file selected contains a connection table which is not a subset of the BLACS connection table.")
                     message.setIcon(QMessageBox.Information)
                     message.setWindowTitle("BLACS")
-                    message.exec_() 
+                    message.exec_()
                 else:
                     logger.info("Front Panel not saved as the connection table in the h5 file '"+current_file+"' didn't match the current connection table.")
                 return
         else:
             with h5py.File(current_file,'w') as hdf5_file:
-                # save connection table, save front panel                    
+                # save connection table, save front panel
                 self.store_front_panel_in_h5(hdf5_file,states,tab_positions,window_data,plugin_data,save_conn_table=True)
-    
+
     @inmain_decorator(wait_for_return=True)
     def store_front_panel_in_h5(self, hdf5_file,tab_data,notebook_data,window_data,plugin_data,save_conn_table=False,save_queue_data=True):
         if save_conn_table:
             if 'connection table' in hdf5_file:
                 del hdf5_file['connection table']
             hdf5_file.create_dataset('connection table', data=self.connection_table.raw_table)
-        
+
         data_group = hdf5_file['/'].create_group('front_panel')
-        
+
         front_panel_list = []
-        other_data_list = []       
+        other_data_list = []
         front_panel_dtype = [('name','a256'),('device_name','a256'),('channel','a256'),('base_value',float),('locked',bool),('base_step_size',float),('current_units','a256')]
         max_od_length = 2 # empty dictionary
-            
+
         # Iterate over each device within a class
         for device_name, device_state in tab_data.items():
-            logger.debug("saving front panel for device:" + device_name) 
+            logger.debug("saving front panel for device:" + device_name)
             # Insert front panel data into dataset
             for hardware_name, data in device_state["front_panel"].items():
                 if data != {}:
@@ -359,29 +371,29 @@ class FrontPanelSettings(object):
                                                  data['base_step_size'] if 'base_step_size' in data else 0,
                                                  data['current_units'] if 'current_units' in data else ''
                                                 )
-                                               )               
+                                               )
                     else:
                         logger.warning('Could not save data for channel %s on device %s because the output value (in base units) was not a string or could not be coerced to a float without loss of precision'%(hardware_name, device_name))
-            
+
             # Save "other data"
             od = repr(device_state["save_data"])
-            other_data_list.append(od)            
-            max_od_length = len(od) if len(od) > max_od_length else max_od_length            
-        
+            other_data_list.append(od)
+            max_od_length = len(od) if len(od) > max_od_length else max_od_length
+
         # Create datasets
         if front_panel_list:
             front_panel_array = numpy.empty(len(front_panel_list),dtype=front_panel_dtype)
             for i, row in enumerate(front_panel_list):
                 front_panel_array[i] = row
             data_group.create_dataset('front_panel',data=front_panel_array)
-                
+
         # Save tab data
         i = 0
         tab_data = numpy.empty(len(notebook_data),dtype=[('tab_name','a256'),('notebook','a2'),('page',int),('visible',bool),('data','a'+str(max_od_length))])
         for device_name,data in notebook_data.items():
             tab_data[i] = (device_name,data["notebook"],data["page"],data["visible"],other_data_list[i])
             i += 1
-            
+
         # Save BLACS Main GUI Info
         dataset = data_group.create_dataset("_notebook_data",data=tab_data)
         dataset.attrs["window_width"] = window_data["_main_window"]["width"]
@@ -398,7 +410,7 @@ class FrontPanelSettings(object):
         for pane_name,pane_position in window_data.items():
             if pane_name != "_main_window":
                 dataset.attrs[pane_name] = pane_position
-        
+
         # Save analysis server settings:
         #dataset = data_group.create_group("analysis_server")
         #dataset.attrs['send_for_analysis'] = self.blacs.analysis_submission.toggle_analysis.get_active()


### PR DESCRIPTION
Adding a try, except block to ensure blacs/blacs/front_panel_settings.py does not attempt to access 'connection table' from the apparatus h5 file before it exists.

The commit for some reason has a decent bit of whitespace changes that were unintended, I can attempt to fix that but the main changes occur in front_panel_settings.py lines 76-84 and a comment explaining in lines 49-52.

