### PR TITLE
Show active config path in window title

### DIFF
--- a/blacs/__main__.py
+++ b/blacs/__main__.py
@@ -98,7 +98,7 @@ from labscript_utils.connections import ConnectionTable
 #Draggable Tab Widget Code
 from labscript_utils.qtwidgets.dragdroptab import DragDropTabWidget
 # Lab config code
-from labscript_utils.labconfig import LabConfig
+from labscript_utils.labconfig import LabConfig, LabscriptApplication
 from labscript_profile import hostname
 # Analysis Submission code
 from blacs.analysis_submission import AnalysisSubmission
@@ -220,7 +220,7 @@ class EasterEggButton(QToolButton):
             inmain(self.setEnabled, True)
 
 
-class BLACS(object):
+class BLACS(LabscriptApplication):
 
     tab_widget_ids = 7
 
@@ -239,10 +239,12 @@ class BLACS(object):
         #loader.registerCustomPromotion('BLACS',BLACSWindow)
         self.ui = loader.load(os.path.join(BLACS_DIR, 'main.ui'), BLACSWindow())
         logger.info('BLACS ui loaded')
+        self.init_config_window_title()
         self.ui.blacs=self
         self.tab_widgets = {}
         self.exp_config = exp_config # Global variable
         self.settings_path = settings_path # Global variable
+        self.set_config_window_title(self.settings_path)
         self.connection_table = connection_table # Global variable
         self.connection_table_h5file = self.exp_config.get('paths','connection_table_h5')
         self.connection_table_labscript = self.exp_config.get('paths','connection_table_py')

--- a/blacs/experiment_queue.py
+++ b/blacs/experiment_queue.py
@@ -23,8 +23,9 @@ from tempfile import gettempdir
 from binascii import hexlify
 
 from qtutils.qt.QtCore import Qt, QItemSelectionModel
-from qtutils.qt.QtGui import QIcon, QAction, QStandardItemModel, QStandardItem
+from qtutils.qt.QtGui import QIcon, QStandardItemModel, QStandardItem
 from qtutils.qt.QtWidgets import (
+    QAction,
     QTreeView,
     QMenu,
     QFileDialog,
@@ -997,4 +998,3 @@ class QueueManager(object):
 
             self.set_status("Idle")
         logger.info('Stopping')
-


### PR DESCRIPTION
change the title bar of the main window of all labscript apps to read "app name - path to app_config_file" for example "runmanager - ~/labscript-suite/app_saved_configs/example_apparatus/runmanager/runmanager.ini". 

This is helpful in verifying that the app is actually accessing the desired configuration file, which has been an ofttimes issue locally.