### PR TITLE
Set macOS application display name

### DIFF
--- a/blacs/__init__.py
+++ b/blacs/__init__.py
@@ -13,4 +13,6 @@
 import os
 from .__version__ import __version__
 
+DESKTOP_APP_MODULE = 'blacs'
+APPLICATION_NAME = 'BLACS'
 BLACS_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/blacs/__main__.py
+++ b/blacs/__main__.py
@@ -15,15 +15,18 @@
 import labscript_utils.excepthook
 
 import os
+from blacs import APPLICATION_NAME, BLACS_DIR, DESKTOP_APP_MODULE
 
 # Associate app windows with OS menu shortcuts:
 import desktop_app
-desktop_app.set_process_appid('blacs')
+desktop_app.set_process_appid(DESKTOP_APP_MODULE)
 
 
 # Splash screen
 from labscript_utils.splash import Splash
-splash = Splash(os.path.join(os.path.dirname(__file__), 'blacs.svg'))
+splash = Splash(
+    os.path.join(BLACS_DIR, 'blacs.svg'), application_name=APPLICATION_NAME
+)
 splash.show()
 
 splash.update_text('importing standard library modules')
@@ -72,11 +75,11 @@ import blacs
 
 
 process_tree = ProcessTree.instance()
-process_tree.zlock_client.set_process_name('BLACS')
+process_tree.zlock_client.set_process_name(APPLICATION_NAME)
 
 
 # Setup logging
-logger = setup_logging('BLACS')
+logger = setup_logging(APPLICATION_NAME)
 labscript_utils.excepthook.set_logger(logger)
 
 logger.info(f'Python version {sys.version}')

--- a/blacs/desktop-app.json
+++ b/blacs/desktop-app.json
@@ -1,4 +1,4 @@
 {
     "product_name": "Labscript Suite",
-    "modules": {"blacs": {"display_name": "BLACS - the labscript suite"}}
+    "modules": {"blacs": {"display_name": "BLACS - the labscript suite", "short_display_name": "BLACS"}}
 }


### PR DESCRIPTION
Support for MacOS specific GUI elements.  Requires partner pull requests made to labscript-utils and desktop-app